### PR TITLE
Unpin googleapis-common-protos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,6 @@ setup(
         ),
     },
     install_requires=(
-        # There's a pre-release 1.55.1b1 that causes an exception during some
-        # error handling. Doesn't appear to be directly related to octoDNS atm,
-        # but not sure. For now preventing things from using the newer
-        # versions. Once
-        # libshttps://github.com/googleapis/api-common-protos/issues/108 has
-        # been resolved we can remove this line
-        'googleapis-common-protos<=1.55.0',
         'google-cloud-core>=1.4.1',
         'google-cloud-dns>=0.32.0',
         'octodns>=0.9.14',


### PR DESCRIPTION
The issues have been tracked down and problematic release(s) pulled. This appears to be 🟢 now. 

/cc https://github.com/googleapis/python-api-common-protos/issues/91#issuecomment-1071479987