### PR TITLE
Pin protobuf to <= 4.21.1, 4.21.2 breaks some gcloud modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'google-cloud-core>=1.4.1',
         'google-cloud-dns>=0.32.0',
         'octodns>=0.9.14',
+        'protobuf<=4.21.1',
     ),
     license='MIT',
     long_description=long_description,


### PR DESCRIPTION
See https://github.com/octodns/octodns-googlecloud/pull/11#issuecomment-1180785101 for details, protobuf is breaking the google cloud modules yet again.

