### PR TITLE
Add DummyDesired.decoded_name for tests

### DIFF
--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -300,7 +300,7 @@ class TestGoogleCloudProvider(TestCase):
     def test__apply(self, *_):
         class DummyDesired:
             def __init__(self, name, changes):
-                self.name = name
+                self.name = self.desired_name = name
                 self.changes = changes
 
         apply_z = Zone("unit.tests.", [])


### PR DESCRIPTION
octoDNS core is likely adding `Zone.decoded_name` and one of the unit tests here passes in a dummy object in place of a Zone which doesn't have that property. This PR adds it to get the tests happy.

This should be shipped before https://github.com/octodns/octodns/pull/922, but we'll hold off to make sure that PR is going forward.

/cc https://github.com/octodns/octodns/pull/922#issuecomment-1221391316