### PR TITLE
Enable support for root NS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v0.0.1 - 2022-01-11 - Moving
+## v0.0.2 - 2022-10-27
+
+* Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)
+
+## v0.0.1 - 2022-01-11
 
 #### Nothworthy Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## v0.0.2 - 2022-10-27
+## v0.0.2 - 2022-??-??
 
 * Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)
 
-## v0.0.1 - 2022-01-11
+## v0.0.1 - 2022-01-11 - Moving
 
 #### Nothworthy Changes
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
 
 ```
 # Start with the latest versions and don't just copy what's here
-octodns==0.9.21
-octodns-googlecloud==0.0.2
+octodns==0.9.14
+octodns-googlecloud==0.0.1
 ```
 
 ##### SHAs

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
 
 ```
 # Start with the latest versions and don't just copy what's here
-octodns==0.9.14
-octodns-googlecloud==0.0.1
+octodns==0.9.21
+octodns-googlecloud==0.0.2
 ```
 
 ##### SHAs
@@ -60,6 +60,10 @@ providers:
 #### Records
 
 GoogleCloudProvider supports A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, and TXT
+
+#### Root NS records
+
+GoogleCloudProvider support full root NS record management
 
 #### Dynamic
 

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -13,7 +13,7 @@ from google.cloud import dns
 from octodns.record import Record
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.1'
 
 
 def _batched_iterator(iterable, batch_size):

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -40,6 +40,7 @@ class GoogleCloudProvider(BaseProvider):
     )
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_ROOT_NS = True
 
     CHANGE_LOOP_WAIT = 5
 

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -13,7 +13,7 @@ from google.cloud import dns
 from octodns.record import Record
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 def _batched_iterator(iterable, batch_size):


### PR DESCRIPTION
Enable `SUPPORTS_ROOT_NS` for the google provider. 

Google Cloud DNS allows for management of root NS records. Enabling this flag (in testing on a hand-edited octodns-googlecloud module) successfully maintained and modified the root NS record for a test domain. 

Note that the Google APIs require that there be some value (you cannot delete root NS records), but octodns-sync since version 0.9.17 has no trouble managing these records in Google Cloud DNS. 