### PR TITLE
Clamp protobuf to < 4.21.9, what a mess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'google-cloud-core>=1.4.1',
         'google-cloud-dns>=0.32.0',
         'octodns>=0.9.14',
-        'protobuf>=4.21.2',
+        'protobuf>=4.21.2,<=4.21.8',
     ),
     license='MIT',
     long_description=long_description,


### PR DESCRIPTION
So as best as i can tell 4.21.9 breaks google-cloud-core somehow. I'm getting really sick of dealing with the google cloud <-> protobuf version breakage issues.  I wasn't able to repro the problem on osx even with 3.10. I could in a python:3.10.8 docker container so hopefully this makes things happy.