### PR TITLE
Version 0.0.2 version bump and CHANGELOG updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2022-??-??
+## v0.0.2 - 2022-10-29
 
 * Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)
 

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -13,7 +13,7 @@ from google.cloud import dns
 from octodns.record import Record
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 def _batched_iterator(iterable, batch_size):


### PR DESCRIPTION
## v0.0.2 - 2022-10-29

* Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)

/cc @rtokarek-fastly 