### PR TITLE
Add support for the ALIAS record type now that Google Cloud DNS suppo…

### DIFF
--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -27,6 +27,7 @@ class GoogleCloudProvider(BaseProvider):
         (
             'A',
             'AAAA',
+            'ALIAS',
             'CAA',
             'CNAME',
             'MX',
@@ -301,6 +302,8 @@ class GoogleCloudProvider(BaseProvider):
 
     _data_for_NS = _data_for_A
 
+    _data_for_ALIAS = _data_for_CNAME
+
     _data_for_PTR = _data_for_CNAME
 
     _fix_semicolons = re.compile(r'(?<!\\);')
@@ -368,6 +371,8 @@ class GoogleCloudProvider(BaseProvider):
         )
 
     _rrset_for_NS = _rrset_for_A
+
+    _rrset_for_ALIAS = _rrset_for_CNAME
 
     _rrset_for_PTR = _rrset_for_CNAME
 

--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -35,6 +35,9 @@ octo_records.append(
     )
 )
 octo_records.append(
+    Record.new(zone, '', {'ttl': 3, 'type': 'ALIAS', 'value': 'a.unit.tests.'})
+)
+octo_records.append(
     Record.new(
         zone,
         'mx1',
@@ -173,6 +176,7 @@ resource_record_sets = [
     (u'a.unit.tests.', u'A', 1, [u'1.1.1.1', u'1.2.3.4']),
     (u'aa.unit.tests.', u'A', 9001, [u'1.2.4.3']),
     (u'aaa.unit.tests.', u'A', 2, [u'1.1.1.3']),
+    (u'unit.tests.', u'ALIAS', 3, [u'a.unit.tests.']),
     (u'cname.unit.tests.', u'CNAME', 3, [u'a.unit.tests.']),
     (
         u'mx1.unit.tests.',


### PR DESCRIPTION
…rts it (https://cloud.google.com/dns/docs/records-overview#:~:text=An%20ALIAS%20record%20is%20a,to%20look%20up%20the%20answer.)