### PR TITLE
v0.0.3 CHANGELOG update and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 - 2023-02-08 - AKA
+
+* Support for `ALIAS` record types
+
 ## v0.0.2 - 2022-10-29
 
 * Enable support for root level NS records (`SUPPORTS_ROOT_NS=true`)

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -13,7 +13,7 @@ from google.cloud import dns
 from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 def _batched_iterator(iterable, batch_size):


### PR DESCRIPTION
## v0.0.3 - 2023-02-08 - AKA

* Support for `ALIAS` record type

/cc https://github.com/octodns/octodns-googlecloud/issues/22 @npaufler @WhatshallIbreaktoday