### PR TITLE
Replace the double escape characters before doublequotes

### DIFF
--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -378,7 +378,7 @@ class GoogleCloudProvider(BaseProvider):
 
     def _rrset_for_SPF(self, gcloud_zone, record):
         return gcloud_zone.resource_record_set(
-            record.fqdn, record._type, record.ttl, record.chunked_values
+            record.fqdn, record._type, record.ttl, [x.replace(r'\\"',r'\"') for x in record.chunked_values]
         )
 
     def _rrset_for_SRV(self, gcloud_zone, record):


### PR DESCRIPTION
Hello!

I'm raising this PR as a potential fix for adding in double quotes `"` into TXT and SPF records.

I struggled to find any way of adding these as when running `octodns-sync --config-file config/develop.yaml` without `--doit`, it would appear a sensible change. However when attempting to push into GCP it would throw up errors showing that escape characters were getting added unexpectedly.

For example here's a text record I try to add:
```
---
test.txt:
  type: TXT
  values:
    - '\"'
```

The dry run looks sensible:
```
********************************************************************************
* <SNIP>.
********************************************************************************
* google (GoogleCloudProvider)
*   Create <TxtRecord TXT 3600, test.txt.<SNIP>., ['\"']> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=0
********************************************************************************
```

Then when running with `--doit`:
```
google.api_core.exceptions.BadRequest: 400 POST https://dns.googleapis.com/dns/v1/projects/<SNIP>/managedZones/<SNIP>/changes?prettyPrint=false: Invalid value for 'entity.change.additions[test.txt.<SNIP>.][TXT].rrdata[0]': '"\\""'
```

Note here that an extra escape character has been added in.

With my change from this branch:
```
********************************************************************************
* <SNIP>.
********************************************************************************
* google (GoogleCloudProvider)
*   Create <TxtRecord TXT 3600, test.txt.<SNIP>., ['\"']> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing Records=0
********************************************************************************


2023-02-23T11:09:47  [4408800768] INFO  GoogleCloudProvider[google] apply: making 1 changes to <SNIP>.
2023-02-23T11:09:53  [4408800768] INFO  Manager sync:   1 total changes
```

And it appears in GCP as expected:
![image](https://user-images.githubusercontent.com/5802488/220890440-ff3a0bfa-c374-46bb-90c9-e6d28f0aebac.png)

Potential problems/caveats are that when creating your config .yaml files the different values need to be single quoted with escape characters. 

Feel free to change up, or decline the PR - I just felt that as this resolved my issues with doublequotes and GCP, this may be useful for someone else out there!
