### PR TITLE
pytest warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,7 @@ line_length=80
 sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    'error',
+]
 pythonpath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ line_length=80
 sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-    'error',
-]
+# google cloud uses lots of deprecated stuff from setuptools/distutils so this
+# would be a waste of time...
+#filterwarnings = [
+#    'error',
+#]
 pythonpath = "."


### PR DESCRIPTION
Bump python warnings to error during pytest, and fix any existing warnings

/cc octodns/octodns#1108
