### PR TITLE
Add trailing dot to record values if it's missing

### DIFF
--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -296,7 +296,7 @@ class GoogleCloudProvider(BaseProvider):
     def _data_for_MX(self, gcloud_record):
         return {
             'values': [
-                {"preference": v[0], "exchange": add_trailing_dot(v[1])}
+                {"preference": v[0], "exchange": v[1]}
                 for v in [shlex.split(g) for g in gcloud_record.rrdatas]
             ]
         }

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -19,10 +19,10 @@ __version__ = __VERSION__ = '0.0.3'
 
 def add_trailing_dot(value):
     """
-    Required function to handle cases where CNAMEs being pushed
+    Required function to handle cases where records being pushed
     to Google Cloud DNS do not end with a dot.
 
-    :param value: Contains the CNAME record value
+    :param value: Contains the record value
     :type  value: str
 
     :type return: str

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -16,6 +16,20 @@ from octodns.record import Record
 # TODO: remove __VERSION__ with the next major version release
 __version__ = __VERSION__ = '0.0.3'
 
+def add_trailing_dot(value):
+    """
+    Required function to handle cases where CNAMEs being pushed 
+    to Google Cloud DNS do not end with a dot.
+
+    :param value: Contains the CNAME record value
+    :type  value: str
+
+    :type return: str
+    """
+    if (value[-1] != '.'):
+        value = value + '.'
+    return value
+
 
 def _batched_iterator(iterable, batch_size):
     n = len(iterable)
@@ -347,6 +361,7 @@ class GoogleCloudProvider(BaseProvider):
         )
 
     def _rrset_for_CNAME(self, gcloud_zone, record):
+        record.value = add_trailing_dot(record.value)
         return gcloud_zone.resource_record_set(
             record.fqdn, record._type, record.ttl, [record.value]
         )

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -16,9 +16,10 @@ from octodns.record import Record
 # TODO: remove __VERSION__ with the next major version release
 __version__ = __VERSION__ = '0.0.3'
 
+
 def add_trailing_dot(value):
     """
-    Required function to handle cases where CNAMEs being pushed 
+    Required function to handle cases where CNAMEs being pushed
     to Google Cloud DNS do not end with a dot.
 
     :param value: Contains the CNAME record value
@@ -26,7 +27,7 @@ def add_trailing_dot(value):
 
     :type return: str
     """
-    if (value[-1] != '.'):
+    if value[-1] != '.':
         value = value + '.'
     return value
 

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -296,7 +296,7 @@ class GoogleCloudProvider(BaseProvider):
     def _data_for_MX(self, gcloud_record):
         return {
             'values': [
-                {"preference": v[0], "exchange": v[1]}
+                {"preference": v[0], "exchange": add_trailing_dot(v[1])}
                 for v in [shlex.split(g) for g in gcloud_record.rrdatas]
             ]
         }
@@ -372,7 +372,10 @@ class GoogleCloudProvider(BaseProvider):
             record.fqdn,
             record._type,
             record.ttl,
-            [f'{v.preference} {v.exchange}' for v in record.values],
+            [
+                f'{v.preference} {add_trailing_dot(v.exchange)}'
+                for v in record.values
+            ],
         )
 
     def _rrset_for_NAPTR(self, gcloud_zone, record):

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -28,7 +28,7 @@ def add_trailing_dot(value):
     :type return: str
     """
     if value[-1] != '.':
-        value = value + '.'
+        value = f'{value}.'
     return value
 
 

--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -9,7 +9,11 @@ from octodns.provider.base import BaseProvider, Plan
 from octodns.record import Create, Delete, Record, Update
 from octodns.zone import Zone
 
-from octodns_googlecloud import GoogleCloudProvider, _batched_iterator
+from octodns_googlecloud import (
+    GoogleCloudProvider,
+    _batched_iterator,
+    add_trailing_dot,
+)
 
 zone = Zone(name='unit.tests.', sub_zones=[])
 octo_records = []
@@ -280,6 +284,9 @@ class DummyIterator:
 
 
 class TestGoogleCloudProvider(TestCase):
+    def test_trailing_dot(self):
+        self.assertEqual(add_trailing_dot('unit.tests'), 'unit.tests.')
+
     @patch('octodns_googlecloud.dns')
     def _get_provider(*args):
         '''Returns a mock GoogleCloudProvider object to use in testing.

--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -286,6 +286,7 @@ class DummyIterator:
 class TestGoogleCloudProvider(TestCase):
     def test_trailing_dot(self):
         self.assertEqual(add_trailing_dot('unit.tests'), 'unit.tests.')
+        self.assertEqual(add_trailing_dot('unit.tests.'), 'unit.tests.')
 
     @patch('octodns_googlecloud.dns')
     def _get_provider(*args):


### PR DESCRIPTION
Purpose of this change is to handle an edge case where I am trying to migrate CNAME and MX records from AWS Route53 to GCP Cloud DNS and I encounter an error at the stage where OctoDNS tries to apply the changes. AWS Route53 is stripping away the trailing dots on their platform and GCP doesn't like it. 