### PR TITLE
feat: handle zone type based on prefix zone name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ providers:
     #  "default credentials"
     # credentials_file: ~/google_cloud_credentials_file.json
     #
+    # If multiple DNS zone have the same DNS name, it's possible
+    # to filter on zone name field based on his prefix. It's a workaround 
+    # to handle private/public zone type based on the prefix zone name. 
+    # zone_prefix: private
+    #
     # GoogleCloudProvider submits changes in batches. The default batch size
     # is 1000, which is also roughly the maximum size that google supports.
     # If your plan & apply makes more than batch_size changes they will be

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -67,6 +67,7 @@ class GoogleCloudProvider(BaseProvider):
         project=None,
         credentials_file=None,
         batch_size=1000,
+        zone_prefix=None,
         *args,
         **kwargs,
     ):
@@ -82,7 +83,7 @@ class GoogleCloudProvider(BaseProvider):
         # Logger
         self.log = getLogger(f'GoogleCloudProvider[{id}]')
         self.id = id
-
+        self.zone_prefix = zone_prefix
         self._gcloud_zones = {}
 
         super().__init__(id, *args, **kwargs)
@@ -211,7 +212,11 @@ class GoogleCloudProvider(BaseProvider):
 
         gcloud_zones = self.gcloud_client.list_zones(page_token=page_token)
         for gcloud_zone in gcloud_zones:
-            self._gcloud_zones[gcloud_zone.dns_name] = gcloud_zone
+            if self.zone_prefix:
+                if gcloud_zone.name.startswith(self.zone_prefix):
+                    self._gcloud_zones[gcloud_zone.dns_name] = gcloud_zone
+            else:
+                self._gcloud_zones[gcloud_zone.dns_name] = gcloud_zone
 
         if gcloud_zones.next_page_token:
             self._get_cloud_zones(gcloud_zones.next_page_token)


### PR DESCRIPTION
As Google cloud python library on managedzone doesn't have zone type attribute, if we want to handle public / private zones, we could use the zone name if we prefix them with private/public or other as a workaround.