### PR TITLE
Add support for DS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.4 - 2025-??-?? - ???
+
+* Support for `DS` record types
+
 ## v0.0.3 - 2023-02-08 - AKA
 
 * Support for `ALIAS` record types

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -76,6 +76,14 @@ dname:
   ttl: 300
   type: DNAME
   value: unit.tests.
+ds:
+  ttl: 9
+  type: DS
+  value:
+    key_tag: 0
+    algorithm: 1
+    digest_type: 2
+    digest: abcdef0123456
 excluded:
   octodns:
     excluded:

--- a/tests/test_octodns_provider_googlecloud.py
+++ b/tests/test_octodns_provider_googlecloud.py
@@ -171,6 +171,30 @@ octo_records.append(
         },
     )
 )
+octo_records.append(
+    Record.new(
+        zone,
+        'ds',
+        {
+            'ttl': 9,
+            'type': 'DS',
+            'values': [
+                {
+                    'key_tag': 0,
+                    'algorithm': 1,
+                    'digest_type': 2,
+                    'digest': 'abcdef0123456',
+                },
+                {
+                    'key_tag': 1,
+                    'algorithm': 2,
+                    'digest_type': 3,
+                    'digest': '0123456abcdef',
+                },
+            ],
+        },
+    )
+)
 for record in octo_records:
     zone.add_record(record)
 
@@ -215,6 +239,12 @@ resource_record_sets = [
         ],
     ),
     (u'caa.unit.tests.', u'CAA', 9, [u'0 issue ca.unit.tests']),
+    (
+        u'ds.unit.tests.',
+        u'DS',
+        9,
+        [u'0 1 2 abcdef0123456', '1 2 3 0123456abcdef'],
+    ),
 ]
 
 


### PR DESCRIPTION
Google Cloud supports DS records for its Cloud DNS product. This change adds support for creating those records.