### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2025-??-?? - ???
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 * Support for `DS` record types
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -14,7 +14,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def add_trailing_dot(value):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.0

* Support for `DS` record types
* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x