### PR TITLE
feat: accept prefix and suffix

### DIFF
--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -59,7 +59,7 @@ def dns_name_to_zone_name(prefix: str|None, dns_name: str, suffix: str|None) -> 
     # Zone name must begin with a letter, end with a letter or digit,
     # and only contain lowercase letters, digits or dashes,
     # and be 63 characters or less
-    zone_name = "-".join(filter(None, [prefix, dns_name.replace(".", "-"), suffix]))
+    zone_name = "-".join(filter(None, [prefix, dns_name.rstrip(".").replace(".", "-"), suffix]))
     zone_name = zone_name[:63]
     return zone_name
 


### PR DESCRIPTION
This pull request adds support for customizable zone name prefixes and suffixes in the Google Cloud DNS provider, improving zone name management and conflict detection. In GCP, a same project can host multiple instances of the same zone (`dns_name` attribute). A way to differentiate those zone is to filter them using the `zone_name` attribute that have to be unique. Using prefix and suffix could be a way to deal with it.

The main changes include introducing a utility function for zone name formatting, updating the provider to accept and use these new options, and enhancing zone filtering logic.

**Zone name customization and management:**

* Added a new function `dns_name_to_zone_name` to generate valid Google Cloud DNS zone names from a DNS name, with optional prefix and suffix, ensuring compliance with naming rules and length limits.
* Updated the `GoogleCloudProvider` class to accept `zone_prefix` and `zone_suffix` parameters, storing them for use in zone name generation. [[1]](diffhunk://#diff-7a1b374cc390aa6b9c5f776889bcd1311f03d1ca7668b67a33baa0a322b88e28R96-R97) [[2]](diffhunk://#diff-7a1b374cc390aa6b9c5f776889bcd1311f03d1ca7668b67a33baa0a322b88e28R110-R112)
* Modified the `_create_gcloud_zone` method to use the new `dns_name_to_zone_name` function for consistent zone naming.

**Zone filtering and conflict detection:**

* Added the `_is_concerned_zone` method to check if a zone matches the configured prefix and suffix, ensuring only relevant zones are managed.
* Enhanced `_get_cloud_zones` to use `_is_concerned_zone` for filtering, and added a check to raise an error if multiple zones with the same DNS name are found, preventing ambiguous management.