### PR TITLE
fix: PtrRecord object has no setter property value

### DIFF
--- a/.changelog/1d2089300a534efb838d27ab24b620ff.md
+++ b/.changelog/1d2089300a534efb838d27ab24b620ff.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fixing issue PtrRecord has no setter for property value

--- a/octodns_googlecloud/__init__.py
+++ b/octodns_googlecloud/__init__.py
@@ -376,9 +376,9 @@ class GoogleCloudProvider(BaseProvider):
         )
 
     def _rrset_for_CNAME(self, gcloud_zone, record):
-        record.value = add_trailing_dot(record.value)
+        value = add_trailing_dot(record.value)
         return gcloud_zone.resource_record_set(
-            record.fqdn, record._type, record.ttl, [record.value]
+            record.fqdn, record._type, record.ttl, [value]
         )
 
     def _rrset_for_DS(self, gcloud_zone, record):


### PR DESCRIPTION
# What does it fix : 

`_rrset_CNAME` is used as handler for `PtrRecord` but `PtrRecord` as no setter for value.  It results in `AttributeError`

We suggest to create a function-scoped variable to avoid this issue.

```
│   File "/usr/local/lib/python3.11/site-packages/octodns_googlecloud/__init__.py", line 427, in _rrset_for_CNAME                                                                                                                                                              │
│     record.value = add_trailing_dot(record.value)                                                                                                                                                                                                                            │
│     ^^^^^^^^^^^^                                                                                                                                                                                                                                                             │
│ AttributeError: property 'value' of 'PtrRecord' object has no setter
```